### PR TITLE
Update Patch Roulette for the Cloudflare Worker backend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@eslint/js": "^10.0.1",
         "@iconify-json/logos": "^1.2.11",
         "@iconify-json/ri": "^1.2.10",
+        "@iconify-json/simple-icons": "^1.2.93",
         "@iconify/tailwind4": "^1.2.3",
         "@sveltejs/adapter-cloudflare": "^7.2.9",
         "@sveltejs/kit": "^2.69.2",
@@ -157,6 +158,8 @@
     "@iconify-json/logos": ["@iconify-json/logos@1.2.11", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ=="],
 
     "@iconify-json/ri": ["@iconify-json/ri@1.2.10", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-WWMhoncVVM+Xmu9T5fgu2lhYRrKTEWhKk3Com0KiM111EeEsRLiASjpsFKnC/SrB6covhUp95r2mH8tGxhgd5Q=="],
+
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.93", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw=="],
 
     "@iconify/tailwind4": ["@iconify/tailwind4@1.2.3", "", { "dependencies": { "@iconify/tools": "^5.0.5", "@iconify/types": "^2.0.0", "@iconify/utils": "^3.1.0" }, "peerDependencies": { "tailwindcss": ">= 4.0.0" } }, "sha512-z8SKiMHRASJKF/IY//87MF88lcB7ulxh8vlhQXXLWsBkNtOh6ese9R41MyGpQeqXdRvQVt+/fX2glQtHFjQ+MA=="],
 
@@ -352,7 +355,7 @@
 
     "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.63.0", "", { "dependencies": { "@typescript-eslint/types": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/utils": "8.63.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.62.1", "", {}, "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
 
     "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.63.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.63.0", "@typescript-eslint/tsconfig-utils": "8.63.0", "@typescript-eslint/types": "8.63.0", "@typescript-eslint/visitor-keys": "8.63.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q=="],
 
@@ -753,20 +756,6 @@
     "@types/mdast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
-
-    "@typescript-eslint/project-service/@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
-
-    "@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
-
-    "@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
-
-    "@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
 
     "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@eslint/js": "^10.0.1",
     "@iconify-json/logos": "^1.2.11",
     "@iconify-json/ri": "^1.2.10",
+    "@iconify-json/simple-icons": "^1.2.93",
     "@iconify/tailwind4": "^1.2.3",
     "@sveltejs/adapter-cloudflare": "^7.2.9",
     "@sveltejs/kit": "^2.69.2",

--- a/src/app.css
+++ b/src/app.css
@@ -16,6 +16,10 @@
   --color-discord: #5865f2;
   --color-modrinth: #00af5c;
   --color-gradle: #209bc4;
-  --color-drizzle: #c5f74f;
+  --color-drizzle: #4d7c0f;
   --color-sqlite: #0f80cc;
+}
+
+[data-theme="dark"] {
+  --color-drizzle: #c5f74f;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -2,7 +2,7 @@
 @plugin "@tailwindcss/typography";
 
 @plugin "@iconify/tailwind4" {
-  prefixes: logos, ri;
+  prefixes: logos, ri, simple-icons;
 }
 
 @plugin "daisyui" {
@@ -16,4 +16,6 @@
   --color-discord: #5865f2;
   --color-modrinth: #00af5c;
   --color-gradle: #209bc4;
+  --color-drizzle: #c5f74f;
+  --color-sqlite: #0f80cc;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -16,7 +16,7 @@
   --color-discord: #5865f2;
   --color-modrinth: #00af5c;
   --color-gradle: #209bc4;
-  --color-drizzle: #4d7c0f;
+  --color-drizzle: #000;
   --color-sqlite: #0f80cc;
 }
 

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -20,6 +20,11 @@ const tech: Record<string, Tech> = {
   drizzle: new Tech("Drizzle", "iconify-color logos--drizzle-icon", "https://orm.drizzle.team"),
   sqlite: new Tech("SQLite", "iconify-color logos--sqlite", "https://sqlite.org"),
   cloudflare: new Tech("Cloudflare", "iconify-color logos--cloudflare-icon", "https://www.cloudflare.com"),
+  cloudflareWorkers: new Tech(
+    "Cloudflare Workers",
+    "iconify-color logos--cloudflare-workers-icon",
+    "https://developers.cloudflare.com/workers/",
+  ),
 };
 
 const allProjects = import.meta.glob("/src/projects/*/*.svx", {

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -17,7 +17,7 @@ const tech: Record<string, Tech> = {
   graphQl: new Tech("GraphQL", "iconify-color logos--graphql", "https://graphql.org"),
   effect: new Tech("Effect", "iconify-color logos--effect-icon", "https://effect.website"),
   hono: new Tech("Hono", "iconify-color logos--hono", "https://hono.dev"),
-  drizzle: new Tech("Drizzle", "iconify simple-icons--drizzle bg-drizzle", "https://orm.drizzle.team"),
+  drizzle: new Tech("Drizzle ORM", "iconify simple-icons--drizzle bg-drizzle", "https://orm.drizzle.team"),
   sqlite: new Tech("SQLite", "iconify simple-icons--sqlite bg-sqlite", "https://sqlite.org"),
   cloudflare: new Tech("Cloudflare", "iconify-color logos--cloudflare-icon", "https://www.cloudflare.com"),
 };

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -17,8 +17,8 @@ const tech: Record<string, Tech> = {
   graphQl: new Tech("GraphQL", "iconify-color logos--graphql", "https://graphql.org"),
   effect: new Tech("Effect", "iconify-color logos--effect-icon", "https://effect.website"),
   hono: new Tech("Hono", "iconify-color logos--hono", "https://hono.dev"),
-  drizzle: new Tech("Drizzle", "iconify-color logos--drizzle-icon", "https://orm.drizzle.team"),
-  sqlite: new Tech("SQLite", "iconify-color logos--sqlite", "https://sqlite.org"),
+  drizzle: new Tech("Drizzle", "iconify simple-icons--drizzle bg-drizzle", "https://orm.drizzle.team"),
+  sqlite: new Tech("SQLite", "iconify simple-icons--sqlite bg-sqlite", "https://sqlite.org"),
   cloudflare: new Tech("Cloudflare", "iconify-color logos--cloudflare-icon", "https://www.cloudflare.com"),
 };
 

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -20,11 +20,6 @@ const tech: Record<string, Tech> = {
   drizzle: new Tech("Drizzle", "iconify-color logos--drizzle-icon", "https://orm.drizzle.team"),
   sqlite: new Tech("SQLite", "iconify-color logos--sqlite", "https://sqlite.org"),
   cloudflare: new Tech("Cloudflare", "iconify-color logos--cloudflare-icon", "https://www.cloudflare.com"),
-  cloudflareWorkers: new Tech(
-    "Cloudflare Workers",
-    "iconify-color logos--cloudflare-workers-icon",
-    "https://developers.cloudflare.com/workers/",
-  ),
 };
 
 const allProjects = import.meta.glob("/src/projects/*/*.svx", {

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -16,6 +16,9 @@ const tech: Record<string, Tech> = {
   springBoot: new Tech("Spring Boot", "iconify-color logos--spring-icon", "https://spring.io/projects/spring-boot"),
   graphQl: new Tech("GraphQL", "iconify-color logos--graphql", "https://graphql.org"),
   effect: new Tech("Effect", "iconify-color logos--effect-icon", "https://effect.website"),
+  hono: new Tech("Hono", "iconify-color logos--hono", "https://hono.dev"),
+  drizzle: new Tech("Drizzle", "iconify-color logos--drizzle-icon", "https://orm.drizzle.team"),
+  sqlite: new Tech("SQLite", "iconify-color logos--sqlite", "https://sqlite.org"),
   cloudflare: new Tech("Cloudflare", "iconify-color logos--cloudflare-icon", "https://www.cloudflare.com"),
 };
 

--- a/src/projects/web-apps/BubbleBuddy.svx
+++ b/src/projects/web-apps/BubbleBuddy.svx
@@ -6,6 +6,7 @@ technologies:
   - typescript
   - node
   - effect
+  - sqlite
   - pnpm
 ---
 

--- a/src/projects/web-apps/patch-roulette.svx
+++ b/src/projects/web-apps/patch-roulette.svx
@@ -7,13 +7,16 @@ technologies:
   - svelteKit
   - tailwind
   - vite
-  - java
-  - springBoot
+  - hono
+  - drizzle
+  - sqlite
   - bun
-  - gradle
+  - cloudflare
 ---
 
 Web app and API for coordinating updates to [Paper](/projects#paper)'s large
 Minecraft patch stack.
 Tracks conflicted patches through assignment and completion states, brokering work between humans
 and agents while recording timing data.
+The Cloudflare Worker serves the UI and API. A Durable Object owns the SQLite database and
+serializes patch claims.

--- a/src/projects/web-apps/patch-roulette.svx
+++ b/src/projects/web-apps/patch-roulette.svx
@@ -11,7 +11,7 @@ technologies:
   - drizzle
   - sqlite
   - bun
-  - cloudflareWorkers
+  - cloudflare
 ---
 
 Web app and API for coordinating updates to [Paper](/projects#paper)'s large

--- a/src/projects/web-apps/patch-roulette.svx
+++ b/src/projects/web-apps/patch-roulette.svx
@@ -8,8 +8,8 @@ technologies:
   - tailwind
   - vite
   - hono
-  - drizzle
   - sqlite
+  - drizzle
   - bun
   - cloudflare
 ---

--- a/src/projects/web-apps/patch-roulette.svx
+++ b/src/projects/web-apps/patch-roulette.svx
@@ -11,7 +11,7 @@ technologies:
   - drizzle
   - sqlite
   - bun
-  - cloudflare
+  - cloudflareWorkers
 ---
 
 Web app and API for coordinating updates to [Paper](/projects#paper)'s large


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Patch Roulette moved off Spring Boot onto a Cloudflare Worker with Durable Object SQLite. This updates the project cards to match.

- Drop Java, Spring Boot, and Gradle from Patch Roulette
- Add Hono, Drizzle, SQLite, and Cloudflare
- Add SQLite to BubbleBuddy (`@effect/sql-sqlite-node`)
- Add `@iconify-json/simple-icons` and use it for the current Drizzle dashes and the SQLite feather. Other badges stay on `logos` / `ri`.
- Drizzle badge color matches their header: black in light mode, brand lime in dark mode.

## Test plan
- [x] `bun run lint`
- [x] `bun run check`
- [ ] Confirm the Patch Roulette and BubbleBuddy cards on `/projects` show the new Drizzle and SQLite marks
- [ ] Check Drizzle badge in light and dark

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02b6b-4620-7fa3-ac48-88653d8e5979?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02b6b-4620-7fa3-ac48-88653d8e5979&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

